### PR TITLE
Fix the issue with lisabeth looping order 

### DIFF
--- a/PassTheTime.cs
+++ b/PassTheTime.cs
@@ -269,8 +269,7 @@ namespace OceanTripPlanner
 
 			if (BotManager.Bots.FirstOrDefault(c => c.Name == "Lisbeth") != null)
 			{
-				await Lisbeth.ExecuteOrders("[{'Item':" + itemId + ",'Amount':" + amount + ",'Type':'" + type + "','QuickSynth':" + quicksynth + ",'Food':" + food + ",'Enabled': true}]");
-
+				await Lisbeth.ExecuteOrders("[{'Item':" + itemId + ",'Amount':" + amount + ",'Type':'" + type + "','QuickSynth':" + quicksynth + ",'Food':" + food + ",'Enabled': true, 'IsPrimary': true, 'AmountMode':'Absolute'}]");
 				AtkAddonControl masterWindow = RaptureAtkUnitManager.GetWindowByName("MasterPieceSupply");
 				if (masterWindow != null)
 				{


### PR DESCRIPTION
because by default sub orders will be put as restock and lisabeth usually put excessive shards into retainer.
With absolute mode it will make sure it goes and do it regardless .