### PR TITLE
Fix achievement DH/TH wasting GP on non-target fish, misleading log, …

### DIFF
--- a/OceanTrip.cs
+++ b/OceanTrip.cs
@@ -454,7 +454,16 @@ namespace OceanTripPlanner
 				{
 					lastLoggedLocation = location;
 					string priorityMode = OceanTripNewSettings.Instance.FishPriority.ToString();
-					string focusMode = FocusFishLog ? "Fish Log" : "Points";
+					string focusMode;
+					if (OceanTripNewSettings.Instance.FishPriority == FishPriority.Achievements)
+					{
+						var focus = AchievementFishDataCache.GetCurrentAchievementFocus();
+						focusMode = focus != AchievementType.None ? focus.ToString() : "None";
+					}
+					else
+					{
+						focusMode = FocusFishLog ? "Fish Log" : "Points";
+					}
 					Log($"Zone: {Schedule.areaName(location)} ({location}), Time: {TimeOfDay}, Stop: {Endeavor.CurrentZone + 1}/3, Priority: {priorityMode} ({focusMode})");
 
 					var zoneRoute = RouteDataCache.GetRoutesWithFish().FirstOrDefault(x => x.Route.RouteShortName == location);

--- a/Strategies/FishingSessionManager.cs
+++ b/Strategies/FishingSessionManager.cs
@@ -253,7 +253,7 @@ namespace OceanTripPlanner.Strategies
 		private async Task MoveToFishingSpot(int spot)
 		{
 			//Navigator.PlayerMover.MoveTowards(FishingConstants.FishSpots[spot]);
-			while (FishingConstants.FishSpots[spot].Distance2DSqr(Core.Me.Location) > 2)
+			while (FishingConstants.FishSpots[spot].Distance2DSqr(Core.Me.Location) > 0.25)
 			{
 				Navigator.PlayerMover.MoveTowards(FishingConstants.FishSpots[spot]);
 				await Coroutine.Yield();

--- a/Strategies/HookingStrategy.cs
+++ b/Strategies/HookingStrategy.cs
@@ -95,12 +95,21 @@ namespace OceanTripPlanner.Strategies
 							AchievementFishDataCache.MapAchievementString(f.Achievement) == achievementFocus);
 					}
 
-					// No achievement fish matched — fall through to points-based DH/TH
+					// Only fall back to points-based DH/TH if no achievement fish can spawn here at all
 					if (!doubleHook)
 					{
-						var matchingFish = FindMatchingFishForHook(context.Location, matchElapsed, context.TimeOfDay, currentWeather);
-						doubleHook = matchingFish.Any(x =>
-							((x.Points * x.THBonus > 600 && x.THBonus > 1) || (x.Points * x.DHBonus > 400 && x.DHBonus > 1)) || (x.THBonus > 5 || x.DHBonus > 3));
+						bool achievementFishAvailable = AchievementFishDataCache.GetFishForLocation(context.Location, achievementFocus)
+							.Any(f => f.TimeOfDayExclusion1 != context.TimeOfDay &&
+								f.TimeOfDayExclusion2 != context.TimeOfDay &&
+								f.WeatherExclusion1 != currentWeather &&
+								f.WeatherExclusion2 != currentWeather);
+
+						if (!achievementFishAvailable)
+						{
+							var matchingFish = FindMatchingFishForHook(context.Location, matchElapsed, context.TimeOfDay, currentWeather);
+							doubleHook = matchingFish.Any(x =>
+								((x.Points * x.THBonus > 600 && x.THBonus > 1) || (x.Points * x.DHBonus > 400 && x.DHBonus > 1)) || (x.THBonus > 5 || x.DHBonus > 3));
+						}
 					}
 				}
 				else if (OceanTripNewSettings.Instance.FishPriority == FishPriority.Points || OceanTripNewSettings.Instance.FishPriority == FishPriority.Auto)

--- a/UI/Forms/FormOceanSettings.cs
+++ b/UI/Forms/FormOceanSettings.cs
@@ -205,6 +205,14 @@ namespace Ocean_Trip
 			overall1mPicture.Image = ImageExtensions.ToGrayScale(UIElements.getIconImage(1, 27));
 			overall3mPicture.Image = ImageExtensions.ToGrayScale(UIElements.getIconImage(1, 27));
 
+			// Wire up achievement checkbox handlers BEFORE data bindings so the
+			// CheckedChanged handler is attached when bindings read initial values.
+			// Without this, reopening the form after dispose loses color icons because
+			// the singleton's properties are already true, the binding fires CheckedChanged
+			// immediately, but no handler is attached yet to set the color image. Then
+			// RefreshAchievements() no-ops (value unchanged) so the icon stays greyscale.
+			SetupAchievementCheckboxHandlers();
+
 			// Achievements Databind
 			mantasPicture.DataBindings.Add("Checked", OceanTripPlanner.FFXIV_Databinds.Instance, "achievementMantas", false, DataSourceUpdateMode.OnPropertyChanged);
 			octopodsPicture.DataBindings.Add("Checked", OceanTripPlanner.FFXIV_Databinds.Instance, "achievementOctopods", false, DataSourceUpdateMode.OnPropertyChanged);
@@ -233,9 +241,6 @@ namespace Ocean_Trip
 			overall500kPicture.DataBindings.Add("Checked", OceanTripPlanner.FFXIV_Databinds.Instance, "achievement500koverall", false, DataSourceUpdateMode.OnPropertyChanged);
 			overall1mPicture.DataBindings.Add("Checked", OceanTripPlanner.FFXIV_Databinds.Instance, "achievement1moverall", false, DataSourceUpdateMode.OnPropertyChanged);
 			overall3mPicture.DataBindings.Add("Checked", OceanTripPlanner.FFXIV_Databinds.Instance, "achievement3moverall", false, DataSourceUpdateMode.OnPropertyChanged);
-
-			// Wire up unified achievement checkbox handler
-			SetupAchievementCheckboxHandlers();
 
 			// Wire up unified radio button handlers
 			SetupRadioButtonHandlers();


### PR DESCRIPTION
…and icon display

- HookingStrategy: Guard points-based DH/TH fallback in achievement mode so it only triggers when no achievement fish can spawn at the current zone/time/weather. Previously fell through unconditionally, burning GP on high-value non-achievement fish (e.g. Mermaid Scale THBonus=7).
- OceanTrip: Show actual achievement target in zone log instead of always displaying "(Points)" — e.g. "Priority: Achievements (Shrimp)".
- FormOceanSettings: Move SetupAchievementCheckboxHandlers() before data bindings so the CheckedChanged handler is attached when bindings read initial values on form reopen, fixing greyscale icons on completed achievements.
- FishingSessionManager: Tighten fishing spot distance threshold.